### PR TITLE
Added Framebuffer resize event

### DIFF
--- a/engine/include/genebits/engine/graphics/window.h
+++ b/engine/include/genebits/engine/graphics/window.h
@@ -246,6 +246,7 @@ struct WindowEvent
 /// Window resize event.
 ///
 /// Published when a window resizes.
+/// Size is in screen coordinate and represents the drawable area
 ///
 struct WindowResizeEvent : public WindowEvent
 {
@@ -408,6 +409,18 @@ DEFINE_ENUM_OPERATORS(WindowMouseButtonEvent::CursorButton)
 struct WindowMouseScrollEvent : public WindowEvent
 {
   int32_t vertical_offset;
+};
+
+///
+/// Window framebuffer resize event.
+///
+/// Published when a window's framebuffer resizes.
+/// Width and height are in pixels
+///
+struct WindowFramebufferResizeEvent : public WindowEvent
+{
+  uint32_t width;
+  uint32_t height;
 };
 
 ///

--- a/engine/source/genebits/engine/graphics/glfw_window.cpp
+++ b/engine/source/genebits/engine/graphics/glfw_window.cpp
@@ -128,6 +128,8 @@ GLFWWindow::GLFWWindow(const std::string& title, uint32_t width, uint32_t height
   GLFW_ASSERT;
   glfwSetScrollCallback(handle_, GLFWMouseScrollCallback);
   GLFW_ASSERT;
+  glfwSetFramebufferSizeCallback(handle_, GLFWFramebufferResizeCallback);
+  GLFW_ASSERT;
 }
 
 GLFWWindow::~GLFWWindow()
@@ -571,6 +573,19 @@ void GLFWWindow::GLFWMouseScrollCallback(GLFWWindow::GLFWWindowHandle handle, do
   GLFW_ASSERT_DEBUG_ONLY;
 
   event.vertical_offset = static_cast<uint32_t>(y_offset);
+
+  GetEnvironment().GetEventBus().Publish(event);
+}
+
+void GLFWWindow::GLFWFramebufferResizeCallback(GLFWWindowHandle handle, int32_t new_width, int32_t new_height)
+{
+  WindowFramebufferResizeEvent event;
+
+  event.window = static_cast<GLFWWindow*>(glfwGetWindowUserPointer(handle));
+  GLFW_ASSERT_DEBUG_ONLY;
+
+  event.width = static_cast<uint32_t>(new_width);
+  event.height = static_cast<uint32_t>(new_height);
 
   GetEnvironment().GetEventBus().Publish(event);
 }

--- a/engine/source/genebits/engine/graphics/glfw_window.h
+++ b/engine/source/genebits/engine/graphics/glfw_window.h
@@ -331,6 +331,15 @@ private:
   ///
   static void GLFWMouseScrollCallback(GLFWWindowHandle handle, double, double y_offset);
 
+  ///
+  /// Callback for when the framebuffer of the window is resized.
+  ///
+  /// @param[in] handle GLFW window handle for the event.
+  /// @param[in] new_width The new width of the buffer in pixels.
+  /// @param[in] new_height The new height of the buffer in pixels.
+  ///
+  static void GLFWFramebufferResizeCallback(GLFWWindowHandle handle, int32_t new_width, int32_t new_height);
+
 private:
   GLFWWindowHandle handle_;
 

--- a/sandbox/basic_window/main.cpp
+++ b/sandbox/basic_window/main.cpp
@@ -15,7 +15,8 @@ struct TestWindowListener : public Listener<TestWindowListener,
                               WindowCursorEnterEvent,
                               WindowCursorMoveEvent,
                               WindowMouseButtonEvent,
-                              WindowMouseScrollEvent>
+                              WindowMouseScrollEvent,
+                              WindowFramebufferResizeEvent>
 {
   void listen(const WindowCloseEvent&)
   {
@@ -75,6 +76,11 @@ struct TestWindowListener : public Listener<TestWindowListener,
   void listen(const WindowMouseScrollEvent& event)
   {
     std::cout << "Mouse scroll event: offset: " << event.vertical_offset << std::endl;
+  }
+
+  void listen(const WindowFramebufferResizeEvent& event)
+  {
+    std::cout << "Window framebuffer resize event: " << event.width << "x" << event.height << std::endl;
   }
 };
 


### PR DESCRIPTION
Added missing event for framebuffer resize. This is needed for a correct implementation since it is not guaranteed that the window resize event's values are representative of the true framebuffer size (In the case of window content scaling)